### PR TITLE
set numpy dependency <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.6',
-    install_requires=['ase','numpy','matplotlib', 'pymatgen', 'colorama'],
+    install_requires=['ase','numpy<2','matplotlib', 'pymatgen', 'colorama'],
     entry_points={
         'console_scripts': [
             'dwbuilder = scripts.dwbuilder:main',


### PR DESCRIPTION
One of the dependencies, pymatgen is not compatible with numpy version >=2.0. Install DWBuilder in a new environment will install numpy 2.0. Although this is not directly related to DWBuilder, it's useful to set numpy<2.0. 